### PR TITLE
Fixing Default AutoField for Django 3.2+

### DIFF
--- a/django_fsm_log/apps.py
+++ b/django_fsm_log/apps.py
@@ -7,6 +7,7 @@ from django_fsm.signals import post_transition, pre_transition
 class DjangoFSMLogAppConfig(AppConfig):
     name = "django_fsm_log"
     verbose_name = "Django FSM Log"
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         backend = import_string(settings.DJANGO_FSM_LOG_STORAGE_METHOD)

--- a/django_fsm_log/apps.py
+++ b/django_fsm_log/apps.py
@@ -7,7 +7,7 @@ from django_fsm.signals import post_transition, pre_transition
 class DjangoFSMLogAppConfig(AppConfig):
     name = "django_fsm_log"
     verbose_name = "Django FSM Log"
-    default_auto_field = 'django.db.models.AutoField'
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
         backend = import_string(settings.DJANGO_FSM_LOG_STORAGE_METHOD)


### PR DESCRIPTION
In Django 3.2, setting:

```python
DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
```

causes a migration to be created for this library.

[Per Django docs](https://docs.djangoproject.com/en/4.0/releases/3.2/#customizing-type-of-auto-created-primary-keys), we can configure the default for each app by modifying the app config.