### PR TITLE
Fix RemovedInDjango41Warning for default_app_config

### DIFF
--- a/django_fsm_log/__init__.py
+++ b/django_fsm_log/__init__.py
@@ -1,4 +1,4 @@
 import django
 
-if django.VERSION < (3, 2):
+if django.VERSION < (4, 0):
     default_app_config = "django_fsm_log.apps.DjangoFSMLogAppConfig"


### PR DESCRIPTION
Django 4.0 warns about it already:

> django.utils.deprecation.RemovedInDjango41Warning: 'django_fsm_log'
defines default_app_config =
'django_fsm_log.apps.DjangoFSMLogAppConfig'. Django now detects this
configuration automatically. You can remove default_app_config.

Note that the tests apparently do not trigger it, but projects using it
might.