### PR TITLE
tests: set USE_TZ to fix RemovedInDjango50Warning

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,3 +32,5 @@ TEMPLATES = [
         },
     },
 ]
+
+USE_TZ = True


### PR DESCRIPTION
> django.utils.deprecation.RemovedInDjango50Warning: The default value
of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to
False in your project settings if you want to keep the current default
behavior.