### PR TITLE
Set app's default_auto_field to match current migrations

### DIFF
--- a/django_fsm_log/apps.py
+++ b/django_fsm_log/apps.py
@@ -7,6 +7,7 @@ from django_fsm.signals import post_transition, pre_transition
 class DjangoFSMLogAppConfig(AppConfig):
     name = "django_fsm_log"
     verbose_name = "Django FSM Log"
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
         backend = import_string(settings.DJANGO_FSM_LOG_STORAGE_METHOD)


### PR DESCRIPTION
Without this it would use `DEFAULT_AUTO_FIELD` from the project's
settings, where the default changed to `BigAutoField`.

docs: https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
ref: https://stackoverflow.com/a/67007098/15690