### PR TITLE
Add description argument to fsm_log_description decorator

### DIFF
--- a/django_fsm_log/decorators.py
+++ b/django_fsm_log/decorators.py
@@ -16,20 +16,19 @@ def fsm_log_by(func):
     return wrapped
 
 
-def fsm_log_description(func=None, allow_inline=False):
+def fsm_log_description(func=None, allow_inline=False, description=""):
     if func is None:
-        return partial(fsm_log_description, allow_inline=allow_inline)
+        return partial(fsm_log_description, allow_inline=allow_inline, description=description)
 
     @wraps(func)
     def wrapped(instance, *args, **kwargs):
         with FSMLogDescriptor(instance, "description") as descriptor:
-            try:
-                description = kwargs["description"]
-            except KeyError:
-                if allow_inline:
-                    kwargs["description"] = descriptor
-                return func(instance, *args, **kwargs)
-            descriptor.set(description)
+            if kwargs.get("description"):
+                descriptor.set(kwargs["description"])
+            elif allow_inline:
+                kwargs["description"] = descriptor
+            else:
+                descriptor.set(description)
             return func(instance, *args, **kwargs)
 
     return wrapped


### PR DESCRIPTION
The aim of this pull request is to give the ability to add a default description to the `fsm_log_description`.
The priority would be:
1. "description" passed as argument when a transition is called
2. "description" set inside the transition if `allow_inline` is `True`
3. default "description" set as default

Example:
```python
@fsm_log_description(description='default')
def execute(self, description=None):
...
```

I find it quite useful since nearly always I have a fixed description to set when running a transition.