### PR TITLE
Fix for django >= 4.0 makemigrations

### DIFF
--- a/django_fsm_log/apps.py
+++ b/django_fsm_log/apps.py
@@ -7,6 +7,7 @@ from django_fsm.signals import post_transition, pre_transition
 class DjangoFSMLogAppConfig(AppConfig):
     name = "django_fsm_log"
     verbose_name = "Django FSM Log"
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
         backend = import_string(settings.DJANGO_FSM_LOG_STORAGE_METHOD)


### PR DESCRIPTION
It's necessary to specify the default_auto_field param in apps.py to inhibit generation of migrations in package