### PR TITLE
Get a different version of pypa/gh-action-pypi-publish. 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   build:
@@ -17,20 +17,22 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           python -m pip install -U setuptools twine wheel
+
       - name: Build package
         run: |
           python setup.py --version
           python setup.py sdist --format=gztar bdist_wheel
           twine check dist/*
+
       - name: Upload packages to Jazzband
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.12.3
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: jazzband
           password: ${{ secrets.JAZZBAND_RELEASE_KEY }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ by enabling a cached backend. See [Advanced Usage](#advanced-usage)
 
 ## Changelog
 
+## 4.0.3 (not released)
+
 ## 4.0.2 (not released)
+
+- Upgrade pypa/gh-action-pypi-publish as an attempt to fix publication of releases to pypi.
 
 ## 4.0.1 (2025-01-07)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readfile(filename):
 
 setup(
     name="django-fsm-log",
-    version="4.0.1",
+    version="4.0.2",
     description="Transition's persistence for django-fsm",
     long_description=readfile("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Taken from https://github.com/jazzband/djangorestframework-simplejwt/blob/master/.github/workflows/release.yml, That successfully published a release yesterday.

Might solve our release issue