### PR TITLE
Maintain tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{39,310,311}-dj-4.2
     py{310,311,312,313}-5.0
     py{310,311,312,313}-5.1
-    py{310,311,312,313}-dj-master
+    py{312,313}-dj-main
 
 [gh-actions]
 python =
@@ -24,4 +24,4 @@ deps =
     dj-4.2: Django>=4.2,<5
     dj-5.0: Django>=5,<5.1
     dj-5.1: Django>=5.1,<5.2
-    dj-master: https://github.com/django/django/archive/master.tar.gz
+    dj-main: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
django main branch requires at least python 3.12